### PR TITLE
[OPS-351] Fix GCP Marketplace CVE vulnerabilities in deployer image

### DIFF
--- a/deployer-image/Dockerfile
+++ b/deployer-image/Dockerfile
@@ -24,7 +24,7 @@ RUN envsubst < /workspace/schema.yaml > /workspace/schema.yaml.processed && \
 # Stage 2: Deployer
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_envsubst:latest
 
-ARG TERRAFORM_VERSION=1.13.4
+ARG TERRAFORM_VERSION=1.14.8
 ARG YQ_VERSION=4.44.6
 
 # Update base system and install security patches
@@ -44,9 +44,7 @@ RUN apt-get update && \
     # Install yq with specific version
     wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 && \
     chmod +x /usr/local/bin/yq && \
-    # Install latest kubectl versions to fix CVE-2025-8959, CVE-2025-61729, and CVE-2025-22868
-    # These vulnerabilities affect kubectl binaries built with vulnerable Go dependencies
-    # Installing latest kubectl versions that were built with fixed Go 1.22.6+ and updated dependencies
+    # Install latest kubectl to get security patches (including CVE-2026-33186 grpc-go auth bypass)
     KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt) && \
     mkdir -p /opt/kubectl/1.30 /opt/kubectl/1.31 && \
     curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
@@ -57,8 +55,8 @@ RUN apt-get update && \
     cp kubectl /opt/kubectl/1.31/kubectl && \
     cp kubectl /usr/local/bin/kubectl && \
     rm kubectl kubectl.sha256 && \
-    # Upgrade pip to latest version to fix CVE-2024-35195 and CVE-2025-47273
-    python3 -m pip install --upgrade pip setuptools wheel --no-cache-dir && \
+    # Upgrade pip and fix CVE-2026-27459 (pyOpenSSL buffer overflow in DTLS cookie callback)
+    python3 -m pip install --upgrade pip setuptools wheel "pyOpenSSL>=26.0.0" --no-cache-dir && \
     # Clean up
     apt-get remove -y wget unzip curl && \
     apt-get autoremove -y && \

--- a/deployer-image/Makefile
+++ b/deployer-image/Makefile
@@ -4,8 +4,8 @@ MPDEV := $(BIN_DIR)/mpdev
 SCHEMA_FILE := marketplace/schema.yaml
 MANIFEST_DIR := marketplace/manifests
 
-TRACK ?= 4.1
-RELEASE ?= ${TRACK}.2
+TRACK ?= 4.2
+RELEASE ?= ${TRACK}.0
 
 # Docker registry and image names
 REGISTRY = gcr.io/stackgen-gcp-marketplace


### PR DESCRIPTION
## Summary

Fixes 3 CVEs flagged by Google Cloud Marketplace's verification pipeline on the deployer image (`stackgen-enterprise-platform-k8s-v2`). Google issued a final reminder on March 24 — the listing risks being hidden if not addressed.

### CVEs Addressed

| CVE | Package | Fix |
|-----|---------|-----|
| **CVE-2026-1229** | `cloudflare/circl` (Go) — incorrect ECC p384 calculation | Bump Terraform 1.13.4 → 1.14.8 (circl v1.6.1 → v1.6.3) |
| **CVE-2026-27459** | `pyOpenSSL` (Python) — buffer overflow in DTLS cookie callback | Add explicit `pyOpenSSL>=26.0.0` to pip install step |
| **CVE-2026-33186** | `google.golang.org/grpc` (Go) — auth bypass via malformed `:path` | Fresh base image pull + latest kubectl at build time |

### Other Changes
- Version track bumped from 4.1 → 4.2 (release 4.2.0)

## Test plan
- [x] Build the deployer image locally with `make build` to verify Dockerfile changes
- [x] Confirm Terraform 1.14.8 downloads and installs correctly
- [x] Confirm pyOpenSSL >= 26.0.0 is installed in the image
- [ ] Push a tag (e.g. `4.2.0`) to trigger the CI workflow and verify image is pushed to GCR
- [ ] Resubmit to GCP Marketplace and verify CVE scan passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployer image with security patches, including Terraform (1.13.4 → 1.14.8), kubectl, and Python dependencies (enforced pyOpenSSL≥26.0.0) to address CVE vulnerabilities.
  * Updated default deployer image versioning from track 4.1 to 4.2 with adjusted release baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->