### PR TITLE
[OPS-351] Fix remaining critical CVEs — yq 4.52.5 + Terraform 1.15.0-rc1

### DIFF
--- a/deployer-image/Dockerfile
+++ b/deployer-image/Dockerfile
@@ -24,8 +24,8 @@ RUN envsubst < /workspace/schema.yaml > /workspace/schema.yaml.processed && \
 # Stage 2: Deployer
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_envsubst:latest
 
-ARG TERRAFORM_VERSION=1.14.8
-ARG YQ_VERSION=4.44.6
+ARG TERRAFORM_VERSION=1.15.0-rc1
+ARG YQ_VERSION=4.52.5
 
 # Update base system and install security patches
 RUN apt-get update && \


### PR DESCRIPTION
## Summary

Follow-up to PR #6. After scanning the pushed 4.2.0 image, GCP Artifact Registry flagged **4 Critical CVEs** (vs 1 on the old image). This PR eliminates all of them.

### CVEs Fixed

| CVE | Severity | Package | Fix |
|-----|----------|---------|-----|
| **CVE-2025-68121** | CRITICAL (CVSS 10) | Go stdlib crypto/tls | yq 4.44.6 → 4.52.5 (Go 1.26.1) |
| **CVE-2026-27143** | CRITICAL (CVSS 9.8) | Go stdlib cmd/compile | yq + TF bump (Go 1.25.7+/1.26.1) |
| **CVE-2026-33186** | CRITICAL (CVSS 9.1) | google.golang.org/grpc | TF 1.14.8 → 1.15.0-rc1 (grpc v1.80.0) |
| **CVE-2025-22871** | CRITICAL (CVSS 9.1) | Go stdlib net/http | TF 1.15.0-rc1 (Go 1.25.7) |

### Trivy scan result after this change
- **CRITICAL: 0**
- HIGH: 16 (all Go stdlib in kubectl, awaiting upstream Go 1.25.9+ build)

### Version changes
- Terraform: 1.14.8 → 1.15.0-rc1
- yq: 4.44.6 → 4.52.5

## Test plan
- [x] Image builds successfully
- [x] Terraform 1.15.0-rc1 installs and runs
- [x] yq 4.52.5 installs and runs
- [x] pyOpenSSL 26.0.0 confirmed
- [x] Trivy scan shows 0 critical CVEs
- [ ] Merge, tag 4.2.1, push tag to trigger CI
- [ ] Verify GCP Artifact Registry shows 0 critical after new image is pushed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Deployer image tool versions: Terraform to 1.15.0-rc1 and yq to 4.52.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->