### PR TITLE
[OPS-351] Update publishedVersion and release to 4.2.1

### DIFF
--- a/deployer-image/Makefile
+++ b/deployer-image/Makefile
@@ -5,7 +5,7 @@ SCHEMA_FILE := marketplace/schema.yaml
 MANIFEST_DIR := marketplace/manifests
 
 TRACK ?= 4.2
-RELEASE ?= ${TRACK}.0
+RELEASE ?= ${TRACK}.2
 
 # Docker registry and image names
 REGISTRY = gcr.io/stackgen-gcp-marketplace

--- a/deployer-image/marketplace/manifests/application.yaml.template
+++ b/deployer-image/marketplace/manifests/application.yaml.template
@@ -11,7 +11,7 @@ metadata:
 spec:
   descriptor:
     type: terraform-runner
-    version: "4.1.2"
+    version: "4.2.2"
     notes: |-
       # This command retrieves the IP address of the proxy-ingress service in the 'stackgen' namespace.
       # It uses kubectl to get the load balancer ingress IP and then constructs the URL.

--- a/deployer-image/marketplace/schema.yaml
+++ b/deployer-image/marketplace/schema.yaml
@@ -3,7 +3,7 @@ x-google-marketplace:
   partnerId: "stackgen-gcp-marketplace"  # Replace with your actual Partner ID
   solutionId: "stackgen-enterprise-platform-k8s-v2.endpoints.stackgen-gcp-marketplace.cloud.goog" # Replace with your actual Product ID
   applicationApiVersion: v1beta1
-  publishedVersion: "4.1.2"
+  publishedVersion: "4.2.2"
   publishedVersionMetadata:
     releaseNote: "Initial release with Job support."
   images:


### PR DESCRIPTION
## Summary

Updates the GCP Marketplace `publishedVersion` and Makefile release to match the 4.2.1 tag.

- `schema.yaml` publishedVersion: 4.1.2 → 4.2.2
- `application.yaml.template` version: 4.1.2 → 4.2.2
- `Makefile` RELEASE: 4.2.0 → 4.2.2

## Test plan
- [ ] Merge, tag `4.2.2`, push tag to rebuild with correct version metadata


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployer image release tag default value
  * Updated terraform-runner application version to 4.2.1
  * Updated marketplace published version to 4.2.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->