### PR TITLE
[OPS-351] Fix marketplace verification tests and bump to 4.2.3

### DIFF
--- a/deployer-image/Dockerfile
+++ b/deployer-image/Dockerfile
@@ -66,12 +66,13 @@ RUN apt-get update && \
 LABEL com.googleapis.cloudmarketplace.product.service.name=services/stackgen-enterprise-platform-k8s-v2.endpoints.stackgen-gcp-marketplace.cloud.goog
 
 # Set timeout for Application readiness check (default is 300 seconds)
-# Increased to 600 seconds (10 minutes) to allow for longer deployment times
-ENV WAIT_FOR_READY_TIMEOUT=600
+# Increased to 900 seconds (15 minutes) to allow for heavy Terraform deployment
+# (PostgreSQL + Temporal + Stackgen Helm charts all with wait=true)
+ENV WAIT_FOR_READY_TIMEOUT=900
 
 # Set timeout for the entire tester process (deploying, running tester pods, waiting for completion)
-# Increased to 900 seconds (15 minutes) to allow for longer deployment and testing times
-ENV TESTER_TIMEOUT=900
+# Increased to 1200 seconds (20 minutes) to allow for longer deployment and testing times
+ENV TESTER_TIMEOUT=1200
 
 # Enable debug logging by default to help diagnose issues
 # Set to "false" to disable verbose output and Terraform debug logs

--- a/deployer-image/Makefile
+++ b/deployer-image/Makefile
@@ -5,7 +5,7 @@ SCHEMA_FILE := marketplace/schema.yaml
 MANIFEST_DIR := marketplace/manifests
 
 TRACK ?= 4.2
-RELEASE ?= ${TRACK}.2
+RELEASE ?= ${TRACK}.3
 
 # Docker registry and image names
 REGISTRY = gcr.io/stackgen-gcp-marketplace

--- a/deployer-image/marketplace/data-test/manifest/tester.yaml.template
+++ b/deployer-image/marketplace/data-test/manifest/tester.yaml.template
@@ -16,15 +16,21 @@ spec:
         - |
           set -e
           echo "Testing pod statuses in stackgen namespace..."
+          FAILED=0
           for pod in $(kubectl get pods -n stackgen -o jsonpath='{.items[*].metadata.name}'); do
             status=$(kubectl get pod $pod -n stackgen -o jsonpath='{.status.phase}')
             echo "Pod $pod status: $status"
-            if [ "$status" != "Running" ]; then
-              echo "Pod $pod is not running. Exiting."
-              exit 1
+            if [ "$status" = "Running" ] || [ "$status" = "Succeeded" ]; then
+              continue
             fi
+            echo "Pod $pod is in unexpected phase: $status"
+            FAILED=1
           done
-          echo "All Pods are running."
+          if [ "$FAILED" -ne 0 ]; then
+            echo "One or more pods are not healthy. Exiting."
+            exit 1
+          fi
+          echo "All pods are healthy."
       env:
         - name: KUBERNETES_SERVICE_HOST
           value: "kubernetes.default.svc"

--- a/deployer-image/marketplace/data-test/schema.yaml
+++ b/deployer-image/marketplace/data-test/schema.yaml
@@ -21,4 +21,4 @@ properties:
     type: string
     title: Global Static IP Name
     description: The name of the global static IP reserved in your GCP account. This IP is used for associating with GCE Ingress.
-    default: 34.8.2.217
+    default: "stackgen-static-ip"

--- a/deployer-image/marketplace/manifests/application.yaml.template
+++ b/deployer-image/marketplace/manifests/application.yaml.template
@@ -11,7 +11,7 @@ metadata:
 spec:
   descriptor:
     type: terraform-runner
-    version: "4.2.2"
+    version: "4.2.3"
     notes: |-
       # This command retrieves the IP address of the proxy-ingress service in the 'stackgen' namespace.
       # It uses kubectl to get the load balancer ingress IP and then constructs the URL.

--- a/deployer-image/marketplace/manifests/job.yaml.template
+++ b/deployer-image/marketplace/manifests/job.yaml.template
@@ -4,6 +4,7 @@ metadata:
   name: $name-job
   namespace: $namespace
   labels:
+    app.kubernetes.io/name: $name
     app.kubernetes.io/instance: $name
 spec:
   template:

--- a/deployer-image/marketplace/schema.yaml
+++ b/deployer-image/marketplace/schema.yaml
@@ -3,7 +3,7 @@ x-google-marketplace:
   partnerId: "stackgen-gcp-marketplace"  # Replace with your actual Partner ID
   solutionId: "stackgen-enterprise-platform-k8s-v2.endpoints.stackgen-gcp-marketplace.cloud.goog" # Replace with your actual Product ID
   applicationApiVersion: v1beta1
-  publishedVersion: "4.2.2"
+  publishedVersion: "4.2.3"
   publishedVersionMetadata:
     releaseNote: "Initial release with Job support."
   images:


### PR DESCRIPTION
## Summary

- **Fix label mismatch**: Added `app.kubernetes.io/name` label to Job template so the Application CR selector can find it — this was the root cause of the `Application did not get ready before timeout` error
- **Fix static IP default**: Changed `global_static_ip_name` default from raw IP (`34.8.2.217`) to a proper GCP address resource name (`stackgen-static-ip`)
- **Fix tester pod**: Updated verification tester to accept `Succeeded` pod phase alongside `Running`, so completed Job pods don't cause false failures
- **Fix timeout inconsistency**: Aligned Dockerfile ENV timeouts with job.yaml.template values (`WAIT_FOR_READY_TIMEOUT=900`, `TESTER_TIMEOUT=1200`)
- **Version bump**: Updated `publishedVersion` and release to `4.2.3` across Makefile, schema.yaml, and application.yaml.template

## Test plan

- [ ] Merge PR and tag `4.2.3` to trigger CI pipeline
- [ ] Verify GCP Marketplace TEST_K8S_APP_FUNCTIONALITY passes on all GKE versions
- [ ] Confirm Application CR becomes Ready within 900s timeout
- [ ] Confirm tester pod does not reject Succeeded pods


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced pod health status verification to accept both Running and Succeeded states during deployment checks.

* **Chores**
  * Extended deployment timeout limits (from 600s to 900s and 900s to 1200s) to accommodate heavier infrastructure deployments.
  * Bumped version to 4.2.3.
  * Updated deployment manifest labels and configuration defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->