### PR TITLE
[OPS-351] Remove ENTRYPOINT override, fix cryptography CVE, bump to 4.2.4

### DIFF
--- a/deployer-image/Dockerfile
+++ b/deployer-image/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update && \
     cp kubectl /usr/local/bin/kubectl && \
     rm kubectl kubectl.sha256 && \
     # Upgrade pip and fix CVE-2026-27459 (pyOpenSSL buffer overflow in DTLS cookie callback)
-    python3 -m pip install --upgrade pip setuptools wheel "pyOpenSSL>=26.0.0" --no-cache-dir && \
+    python3 -m pip install --upgrade pip setuptools wheel "pyOpenSSL>=26.0.0" "cryptography>=46.0.7" --no-cache-dir && \
     # Clean up
     apt-get remove -y wget unzip curl && \
     apt-get autoremove -y && \
@@ -91,6 +91,3 @@ RUN chmod +x /data/deploy.sh
 
 # Copy Terraform configurations
 COPY terraform/ /data/terraform/
-
-# Define entrypoint
-ENTRYPOINT ["/data/deploy.sh"]

--- a/deployer-image/Makefile
+++ b/deployer-image/Makefile
@@ -5,7 +5,7 @@ SCHEMA_FILE := marketplace/schema.yaml
 MANIFEST_DIR := marketplace/manifests
 
 TRACK ?= 4.2
-RELEASE ?= ${TRACK}.3
+RELEASE ?= ${TRACK}.4
 
 # Docker registry and image names
 REGISTRY = gcr.io/stackgen-gcp-marketplace

--- a/deployer-image/marketplace/manifests/application.yaml.template
+++ b/deployer-image/marketplace/manifests/application.yaml.template
@@ -11,7 +11,7 @@ metadata:
 spec:
   descriptor:
     type: terraform-runner
-    version: "4.2.3"
+    version: "4.2.4"
     notes: |-
       # This command retrieves the IP address of the proxy-ingress service in the 'stackgen' namespace.
       # It uses kubectl to get the load balancer ingress IP and then constructs the URL.

--- a/deployer-image/marketplace/schema.yaml
+++ b/deployer-image/marketplace/schema.yaml
@@ -3,7 +3,7 @@ x-google-marketplace:
   partnerId: "stackgen-gcp-marketplace"  # Replace with your actual Partner ID
   solutionId: "stackgen-enterprise-platform-k8s-v2.endpoints.stackgen-gcp-marketplace.cloud.goog" # Replace with your actual Product ID
   applicationApiVersion: v1beta1
-  publishedVersion: "4.2.3"
+  publishedVersion: "4.2.4"
   publishedVersionMetadata:
     releaseNote: "Initial release with Job support."
   images:


### PR DESCRIPTION
## Summary

- **Remove `ENTRYPOINT ["/data/deploy.sh"]` from Dockerfile** — This was overriding the `deployer_envsubst` base image's entrypoint, preventing it from processing manifest templates and creating the Application CR + Job resources. The deployer container would run `deploy.sh` directly (which fails immediately because `/data/values.yaml` isn't mounted in the deployer context), causing `BackoffLimitExceeded` on every GKE version during Marketplace verification. The Job template already specifies `command: ["/data/deploy.sh"]`, so the Terraform runner Job is unaffected.
- **Add `cryptography>=46.0.7`** to pip install to fix CVE-2026-39892 (affected version: 46.0.5).
- **Bump version to 4.2.4** across Makefile, `schema.yaml`, and `application.yaml.template`.

## GCP Marketplace Errors Fixed

| Error | Root Cause | Fix |
|-------|-----------|-----|
| `TEST_K8S_APP_FUNCTIONALITY` — deployer `BackoffLimitExceeded` on K8s 1.33/1.35 | `ENTRYPOINT` override bypassed base image template processing | Removed `ENTRYPOINT` directive |
| `CHECK_PACKAGE_VULNERABILITIES` — CVE-2026-39892 in `cryptography` 46.0.5 | Missing pip constraint | Added `cryptography>=46.0.7` |

## Test plan

- [ ] Tag `4.2.4` after merge and push to trigger CI build
- [ ] Verify the new image passes `mpdev verify` locally
- [ ] Resubmit for GCP Marketplace verification and confirm `TEST_K8S_APP_FUNCTIONALITY` passes
- [ ] Confirm `CHECK_PACKAGE_VULNERABILITIES` no longer reports CVE-2026-39892


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Bumped deployer image version from 4.2.3 to 4.2.4
  * Updated security dependencies, including the latest cryptography library
  * Modified deployment initialization configuration for improved stability and security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->